### PR TITLE
Fix dropping foreign key

### DIFF
--- a/migrations/4.sql
+++ b/migrations/4.sql
@@ -1,5 +1,5 @@
 ALTER TABLE `instance` 
-DROP FOREIGN KEY `fk_geofence_name`;
+DROP KEY `fk_geofence_name`;
 
 ALTER TABLE `instance` 
 CHANGE `geofence` `geofences` longtext NOT NULL;


### PR DESCRIPTION
This migration could not be executed because it failed to drop the key. 
This change fixed it.